### PR TITLE
bump govuk frontend to 4.x and add missing dotenv dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "webpack-node-externals": "^3.0.0"
       },
       "peerDependencies": {
-        "govuk-frontend": "^3.14.0"
+        "govuk-frontend": "^4.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7005,9 +7005,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "peer": true,
       "engines": {
         "node": ">= 4.2.0"
@@ -19365,9 +19365,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "peer": true
     },
     "graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-loader": "^9.1.3",
     "core-js": "^2.6.11",
     "css-loader": "^6.8.1",
+    "dotenv": "^16.3.1",
     "husky": "^8.0.3",
     "jest": "^29.6.3",
     "jest-environment-jsdom": "^29.6.3",
@@ -54,7 +55,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "peerDependencies": {
-    "govuk-frontend": "^3.14.0"
+    "govuk-frontend": "^4.0.0"
   },
   "dependencies": {
     "axios": "^1.5.0",


### PR DESCRIPTION
- bumps govuk-frontend to 4.x to maintain compatibility with flood-app
- adds missing dotenv dev dependency