### PR TITLE
FSR-1064 - allow override of authentication and well known uri

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,13 @@
 {
   "presets": [
+    [
       "@babel/preset-env",
-      "@babel/preset-react"
+      {
+        "targets": {
+          "node": "18"
+        }
+      }
+    ],
+    "@babel/preset-react"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -5,5 +5,87 @@
 - [How to Publish](./docs/how-to-publish.md)
 
 ## Usage
-TBC
+
+### Installation
+
+Run:
+
+```shell
+npm i @defra/flood-webchat
+```
+
+### Assets
+
+You need to copy `./assets/audio/notification.mp3` to your 'assets' directory. This is the notification sound users will
+hear when they receive a message.
+
+### Server Side Javascript
+
+You will need to implement an endpoint on your server which checks the availability of webchat. An express example can
+be seen below:
+
+```js
+
+import getAvailability from '@defra/flood-webchat'
+//... the rest of your server setup
+const webchatOptions = {
+  clientId: process.env.CXONE_CLIENT_ID,
+  clientSecret: process.env.CXONE_CLIENT_SECRET,
+  accessKey: process.env.CXONE_ACCESS_KEY,
+  accessSecret: process.env.CXONE_ACCESS_SECRET,
+  skillEndpoint: process.env.CXONE_SKILL_ENDPOINT,
+  hoursEndpoint: process.env.CXONE_HOURS_ENDPOINT,
+  maxQueueCount: process.env.CXONE_MAX_QUEUE_COUNT
+}
+
+app.get('/webchat-availability', async (req, res, next) => {
+  try {
+    const response = await getAvailability(webchatOptions)
+    return res.status(200).json(response)
+  } catch (err) {
+    next(err)
+  }
+})
+```
+
+### Client Side Javascript
+
+You will also need to initialise webchat in your client side code:
+
+```js
+import * as webchat from '@defra/flood-webchat';
+
+if (document.getElementById('wc-availability')) {
+  webchat.init(document.querySelector('#wc-availability'), {
+    brandId: 'your brand id',
+    channelId: 'your channel id',
+    environmentName: 'your environment name',
+    availabilityEndpoint: '/webchat-availability',
+    audioUrl: 'path/to/notification.mp3'
+  })
+}
+```
+
+### HTML
+
+In your html, will need to add the "Start Chat" link with some placeholder text for if webchat is not supported in the
+user's browser.
+
+```html
+
+<div id="wc-availability">
+    <p>Webchat is not supported with your browser</p>
+</div>
+```
+
+And finally a script tag, to prevent the webchat widget "flashing" on page load/reload.
+
+```html
+
+<script>
+    if (window.location.hash === '#webchat' && window.matchMedia('(max-width: 640px)').matches) {
+        document.body.classList.add('wc-hidden')
+    }
+</script>
+```
 

--- a/__tests__/server/index.test.js
+++ b/__tests__/server/index.test.js
@@ -1,4 +1,4 @@
-import { authenticate, getActivity, getHost, getIsOpen } from '../../src/server/lib/client.js'
+import { authenticate, getActivity, getApiBaseUrl, getIsOpen } from '../../src/server/lib/client.js'
 import getAvailability from '../../src/server/index.js'
 
 jest.mock('../../src/server/lib/client.js')
@@ -9,7 +9,7 @@ const mocks = {
     token: 'some-token',
     tokenType: 'some-token-type'
   }),
-  getHost: jest.mocked(getHost).mockReturnValue('some-host'),
+  getApiBaseUrl: jest.mocked(getApiBaseUrl).mockReturnValue('https://some-host.example'),
   getIsOpen: jest.mocked(getIsOpen),
   getActivity: jest.mocked(getActivity)
 }

--- a/__tests__/server/lib/client.test.js
+++ b/__tests__/server/lib/client.test.js
@@ -1,9 +1,9 @@
 import axios from 'axios'
-import { authenticate, getHost, getActivity, getIsOpen } from '../../../src/server/lib/client'
+import { authenticate, getApiBaseUrl, getActivity, getIsOpen } from '../../../src/server/lib/client'
 
 jest.mock('axios')
 
-describe('getHost()', () => {
+describe('getApiBaseUrl()', () => {
   afterEach(() => {
     jest.clearAllMocks()
   })
@@ -13,15 +13,16 @@ describe('getHost()', () => {
 
     axios.get.mockResolvedValue({
       data: {
-        area: 'uk123456789'
+        api_endpoint: 'https://api-uk123456789.niceincontact.com'
       }
     })
 
-    const result = await getHost({
+    const result = await getApiBaseUrl({
+      wellKnownUri: 'https://cxone.niceincontact.com/.well-known/cxone-configuration',
       tenantId: 12345
     })
 
-    expect(result).toBe('api-uk123456789.niceincontact.com')
+    expect(result).toBe('https://api-uk123456789.niceincontact.com')
     expect(axiosGetSpy.mock.calls[0][0]).toEqual('https://cxone.niceincontact.com/.well-known/cxone-configuration?tenantId=12345')
   })
 })
@@ -46,13 +47,13 @@ describe('getActivity', () => {
     const result = await getActivity({
       token: 'some-token',
       tokenType: 'some-token-type',
-      host: 'test-host',
+      baseUrl: 'https://test.example',
       skillEndpoint: '/test-endpoint',
       maxQueueCount: '2'
     })
 
     expect(result).toStrictEqual({ hasAgentsAvailable: true, hasCapacity: true })
-    expect(axiosGetSpy.mock.calls[0][0]).toEqual('https://test-host/test-endpoint')
+    expect(axiosGetSpy.mock.calls[0][0]).toEqual('https://test.example/test-endpoint')
   })
 
   it('should return false when agent is NOT availible and the is No capacity', async () => {
@@ -70,13 +71,13 @@ describe('getActivity', () => {
     const result = await getActivity({
       token: 'some-token',
       tokenType: 'some-token-type',
-      host: 'test-host',
+      baseUrl: 'https://test.example',
       skillEndpoint: '/test-endpoint',
       maxQueueCount: '2'
     })
 
     expect(result).toStrictEqual({ hasAgentsAvailable: false, hasCapacity: false })
-    expect(axiosGetSpy.mock.calls[0][0]).toEqual('https://test-host/test-endpoint')
+    expect(axiosGetSpy.mock.calls[0][0]).toEqual('https://test.example/test-endpoint')
   })
 })
 
@@ -170,12 +171,12 @@ describe('getIsOpen()', () => {
     const result = await getIsOpen({
       token: 'test-token',
       tokenType: 'test-token-type',
-      host: 'test-host',
+      baseUrl: 'https://test.example',
       hoursEndpoint: '/test-endpoint'
     })
 
     expect(result).toBe(true)
-    expect(axiosGetSpy.mock.calls[0][0]).toEqual('https://test-host/test-endpoint')
+    expect(axiosGetSpy.mock.calls[0][0]).toEqual('https://test.example/test-endpoint')
   })
 })
 
@@ -195,6 +196,7 @@ describe('authenticate()', () => {
     })
 
     const result = await authenticate({
+      authenticationUri: 'https://cxone.niceincontact.com/auth/token',
       authorisation: 'some-token',
       accessKey: 'some-acess-token',
       accessSecret: 'secret-key'
@@ -211,7 +213,7 @@ describe('authenticate()', () => {
     expect(axios.post).toHaveBeenCalledWith('https://cxone.niceincontact.com/auth/token', expectedRequestBody, {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
-        Host: 'eu1.niceincontact.com',
+        Host: 'cxone.niceincontact.com',
         Authorization: 'some-token'
       },
       signal: expect.any(Object)

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -38,8 +38,8 @@ module.exports = async function getAvailability ({
   const apiBaseUrl = await getApiBaseUrl({ wellKnownUri, tenantId })
 
   const [{ hasCapacity, hasAgentsAvailable }, isOpen] = await Promise.all([
-    getActivity({ tokenType, token, baseUrl: apiBaseUrl, skillEndpoint, maxQueueCount }),
-    getIsOpen({ token, tokenType, baseUrl: apiBaseUrl, hoursEndpoint })
+    getActivity({ baseUrl: apiBaseUrl, tokenType, token, skillEndpoint, maxQueueCount }),
+    getIsOpen({ baseUrl: apiBaseUrl, token, tokenType, hoursEndpoint })
   ])
 
   const isAvailable = isOpen && hasAgentsAvailable && hasCapacity

--- a/src/server/lib/client.js
+++ b/src/server/lib/client.js
@@ -5,25 +5,22 @@ const { isWithinHours } = require('./utils.js')
 
 const contentType = 'application/x-www-form-urlencoded'
 
-const authenticate = async ({ authorisation, accessKey, accessSecret }) => {
-  const uri = 'https://cxone.niceincontact.com/auth/token'
-
-  const config = {
-    signal: AbortSignal.timeout(3000),
-    headers: {
-      Host: 'eu1.niceincontact.com',
-      'Content-Type': contentType,
-      Authorization: authorisation
-    }
-  }
-
+const authenticate = async ({ authenticationUri, authorisation, accessKey, accessSecret }) => {
+  const url = new URL(authenticationUri)
   const body = querystring.stringify({
     grant_type: 'password',
     username: accessKey,
     password: accessSecret
   })
 
-  const auth = await axios.post(uri, body, config)
+  const auth = await axios.post(url.href, body, {
+    signal: AbortSignal.timeout(3000),
+    headers: {
+      Host: url.host,
+      'Content-Type': contentType,
+      Authorization: authorisation
+    }
+  })
 
   return {
     token: auth.data.access_token,
@@ -32,30 +29,31 @@ const authenticate = async ({ authorisation, accessKey, accessSecret }) => {
   }
 }
 
-const getHost = async ({ tenantId }) => {
-  const uri = `https://cxone.niceincontact.com/.well-known/cxone-configuration?tenantId=${tenantId}`
+const getApiBaseUrl = async ({ wellKnownUri, tenantId }) => {
+  const url = new URL(wellKnownUri)
+  url.searchParams.set('tenantId', tenantId)
 
-  const config = {
+  const { data } = await axios.get(url.href, {
+    headers: {
+      Host: url.host
+    },
     signal: AbortSignal.timeout(3000)
-  }
+  })
 
-  const api = await axios.get(uri, config)
-
-  return `api-${api.data.area}.niceincontact.com`
+  return data.api_endpoint
 }
 
-const getActivity = async ({ tokenType, token, host, skillEndpoint, maxQueueCount }) => {
-  const config = {
+const getActivity = async ({ tokenType, token, baseUrl, skillEndpoint, maxQueueCount }) => {
+  const url = new URL(skillEndpoint, baseUrl)
+
+  const skill = await axios.get(url.href, {
     signal: AbortSignal.timeout(3000),
     headers: {
-      Host: host,
+      Host: url.host,
       Authorization: `${tokenType} ${token}`,
       'Content-Type': contentType
     }
-  }
-  const uri = `https://${host}${skillEndpoint}`
-
-  const skill = await axios.get(uri, config)
+  })
 
   const activity = skill.data.skillActivity[0]
 
@@ -65,19 +63,17 @@ const getActivity = async ({ tokenType, token, host, skillEndpoint, maxQueueCoun
   }
 }
 
-const getIsOpen = async ({ host, token, tokenType, hoursEndpoint }) => {
-  const config = {
+const getIsOpen = async ({ baseUrl, token, tokenType, hoursEndpoint }) => {
+  const url = new URL(hoursEndpoint, baseUrl)
+
+  const hours = await axios.get(url.href, {
     signal: AbortSignal.timeout(3000),
     headers: {
-      Host: 'api-l36.niceincontact.com',
+      Host: url.host,
       Authorization: `${tokenType} ${token}`,
       'Content-Type': contentType
     }
-  }
-
-  const uri = `https://${host}${hoursEndpoint}`
-
-  const hours = await axios.get(uri, config)
+  })
 
   const days = hours.data.resultSet.hoursOfOperationProfiles[0].days
 
@@ -86,7 +82,7 @@ const getIsOpen = async ({ host, token, tokenType, hoursEndpoint }) => {
 
 module.exports = {
   authenticate,
-  getHost,
+  getApiBaseUrl,
   getIsOpen,
   getActivity
 }


### PR DESCRIPTION
This PR updates the serverside code so that it is possible to override the endpoints used.
This is to enable mocking these out in integration/e2e tests if desired.

It also updates the babel config to switch the target to node18. This stops babel polyfilling so much code, and instead leaves it to the consuming app to do so, which in turn reduces duplicate code and results in smaller bundle sizes.

It also makes the compiled code more readable and easier to debug.