### PR TITLE
chore: sync package-lock after querystring removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "jwt-decode": "3.1.2",
         "lodash.debounce": "4.0.8",
         "luxon": "3.7.2",
-        "querystring": "0.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "uuid": "9.0.1"
@@ -13533,15 +13532,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/querystring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -26268,11 +26258,6 @@
       "requires": {
         "side-channel": "^1.1.0"
       }
-    },
-    "querystring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
     },
     "queue-microtask": {
       "version": "1.2.3",


### PR DESCRIPTION
updated package-lock.json